### PR TITLE
Allow all Rust functions to work properly in wasm, update FROG example accordingly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -198,7 +198,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_VERSION }} -C target-feature=+atomics,+bulk-memory
+          args: --release --out dist -i ${{ env.PYTHON_VERSION }} -- -C target-feature=+atomics,+bulk-memory
           sccache: "true"
           rust-toolchain: nightly-2025-01-01
       - name: Upload wheels

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,6 +195,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: pip install pyodide-build
       - name: Build wheels
+        env:
+          RUSTFLAGS: "-C target-feature=+atomics,+bulk-memory"
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -198,7 +198,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_VERSION }}
+          args: --release --out dist -i ${{ env.PYTHON_VERSION }} -C target-feature=+atomics,+bulk-memory
           sccache: "true"
           rust-toolchain: nightly-2025-01-01
       - name: Upload wheels

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 # C extensions
 *.so
 
+#public folder for wasm notebooks
+public/
+
 # Distribution / packaging
 .Python
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,9 @@ __pycache__/
 # C extensions
 *.so
 
-#public folder for wasm notebooks
+#public folder for wasm notebooks and compiled demos
 public/
-
+examples/frog/
 # Distribution / packaging
 .Python
 .venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,6 @@ version = "0.1.0"
 dependencies = [
  "numpy",
  "pyo3",
- "rayon",
- "wasm-bindgen",
- "wasm-bindgen-rayon",
 ]
 
 [[package]]
@@ -18,58 +15,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "heck"
@@ -84,26 +29,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "log"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matrixmultiply"
@@ -290,38 +219,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
- "wasm_sync",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
- "wasm_sync",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustversion"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "syn"
@@ -351,94 +252,3 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
-dependencies = [
- "crossbeam-channel",
- "js-sys",
- "rayon",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "wasm_sync"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,8 @@ dependencies = [
  "numpy",
  "pyo3",
  "rayon",
+ "wasm-bindgen",
+ "wasm-bindgen-rayon",
 ]
 
 [[package]]
@@ -16,6 +18,27 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -61,10 +84,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matrixmultiply"
@@ -175,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
  "indoc",
  "libc",
@@ -192,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -202,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -212,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -224,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -258,6 +297,7 @@ checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -268,6 +308,7 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -275,6 +316,12 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "syn"
@@ -304,3 +351,94 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "numpy",
  "pyo3",
+ "rayon",
 ]
 
 [[package]]
@@ -15,6 +16,37 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "heck"
@@ -217,6 +249,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 numpy = "0.25.0"
-pyo3 = "0.25.0"
+pyo3 = "0.25.1"
 rayon = "1.10.0"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-rayon = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["cdylib"]
 [dependencies]
 numpy = "0.25.0"
 pyo3 = "0.25.1"
+rayon = "1.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,4 @@ crate-type = ["cdylib"]
 [dependencies]
 numpy = "0.25.0"
 pyo3 = "0.25.1"
-rayon = "1.10.0"
-wasm-bindgen = "0.2.100"
-wasm-bindgen-rayon = "1.3.0"
+

--- a/examples/frog.py
+++ b/examples/frog.py
@@ -13,8 +13,7 @@ async def _():
     if is_in_web_notebook:
         import micropip
         import os
-        os.environ['RAYON_NUM_THREADS'] = '1'
-        path_to_attoworld = mo.notebook_location() / "public" / "attoworld-2025.0.37-cp312-cp312-emscripten_3_1_58_wasm32.whl"
+        path_to_attoworld = mo.notebook_location() / "public" / "attoworld-2025.0.38-cp312-cp312-emscripten_3_1_58_wasm32.whl"
         await micropip.install(str(path_to_attoworld))
     else:
         import tkinter as tk
@@ -54,7 +53,7 @@ def _(aw, bin_spatial_chirp_correction, calibration_selector, file_browser):
             )
             input_data = calibration.apply_to_spectrogram(input_data)
         if bin_spatial_chirp_correction.value:
-            input_data.to_removed_spatial_chirp()   
+            input_data.to_removed_spatial_chirp()
     else:
         input_data = None
     return (input_data,)
@@ -118,7 +117,7 @@ def _(
         if bin_median.value:
             _method = "median"
         else:
-            _method = "mean"    
+            _method = "mean"
         frog_data = (
             input_data.to_block_binned(
                 int(bin_fblock.value), int(bin_tblock.value), method=_method
@@ -222,7 +221,7 @@ def _(filedialog, is_in_web_notebook, mo, plot, result, save_plot_button):
             dat = fh.read()
 
         blob = Blob.new([dat], {type : 'application/image'})
-        url = window.URL.createObjectURL(blob) 
+        url = window.URL.createObjectURL(blob)
         window.location.assign(url)
     else:
         _file_path = filedialog.asksaveasfilename(

--- a/examples/frog.py
+++ b/examples/frog.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.14.16"
+__generated_with = "0.14.17"
 app = marimo.App(width="medium")
 
 
@@ -12,6 +12,8 @@ async def _():
     is_in_web_notebook = sys.platform == "emscripten"
     if is_in_web_notebook:
         import micropip
+        import os
+        os.environ['RAYON_NUM_THREADS'] = '1'
         path_to_attoworld = mo.notebook_location() / "public" / "attoworld-2025.0.37-cp312-cp312-emscripten_3_1_58_wasm32.whl"
         await micropip.install(str(path_to_attoworld))
     else:
@@ -218,7 +220,7 @@ def _(filedialog, is_in_web_notebook, mo, plot, result, save_plot_button):
         plot.savefig("/test.svg")
         with open('/test.svg', 'r') as fh:
             dat = fh.read()
-        
+
         blob = Blob.new([dat], {type : 'application/image'})
         url = window.URL.createObjectURL(blob) 
         window.location.assign(url)

--- a/examples/frog.py
+++ b/examples/frog.py
@@ -29,7 +29,7 @@ async def _():
 
 @app.cell
 def _(mo):
-    file_browser = mo.ui.file(filetypes=[".dwc"], label="Select file")
+    file_browser = mo.ui.file(filetypes=[".dwc"], label="Select .dwc file")
     file_browser
     return (file_browser,)
 
@@ -203,7 +203,7 @@ def _(filedialog, is_in_web_notebook, mo, result, save_button):
             title="Save File", filetypes=[("All Files", "*.*")]
         )
 
-        if _file_path is not None and result is not None:
+        if (_file_path is not None) and (result is not None) and (_file_path != ""):
             result.save(_file_path)
             result.save_yaml(_file_path + ".yaml")
     return
@@ -212,7 +212,17 @@ def _(filedialog, is_in_web_notebook, mo, result, save_button):
 @app.cell
 def _(filedialog, is_in_web_notebook, mo, plot, result, save_plot_button):
     mo.stop(not save_plot_button.value)
-    if not is_in_web_notebook:
+    if is_in_web_notebook:
+        from js import Blob, document
+        from js import window
+        plot.savefig("/test.svg")
+        with open('/test.svg', 'r') as fh:
+            dat = fh.read()
+        
+        blob = Blob.new([dat], {type : 'application/image'})
+        url = window.URL.createObjectURL(blob) 
+        window.location.assign(url)
+    else:
         _file_path = filedialog.asksaveasfilename(
             title="Save File", filetypes=[("SVG files", "*.svg"), ("PDF files", "*.pdf")]
         )

--- a/examples/frog.py
+++ b/examples/frog.py
@@ -14,6 +14,7 @@ async def _():
         import micropip
         import os
         path_to_attoworld = mo.notebook_location() / "public" / "attoworld-2025.0.38-cp312-cp312-emscripten_3_1_58_wasm32.whl"
+        micropip.uninstall("attoworld")
         await micropip.install(str(path_to_attoworld))
     else:
         import tkinter as tk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "A", "ICN", "PIE", "RET", "ARG", "D"]
-ignore = ["E501", "D401", "D205", "D211", "D213"]
+ignore = ["E501", "D401", "D205", "D211", "D213", "D203"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "attoworld"
-version = "2025.0.37"
+version = "2025.0.38"
 authors = [{ name = "Nick Karpowicz", email = "nicholas.karpowicz@mpq.mpg.de" }]
 dependencies = [
     "numpy",

--- a/python/attoworld/data/complex_envelope.py
+++ b/python/attoworld/data/complex_envelope.py
@@ -15,7 +15,6 @@ from .decorators import yaml_io
 @yaml_io
 @dataclass(slots=True)
 class ComplexEnvelope:
-
     """Data corresponding to a complex envelope of a pulse, e.g. from a FROG measurement.
 
     Attributes:

--- a/python/attoworld/data/complex_spectrum.py
+++ b/python/attoworld/data/complex_spectrum.py
@@ -11,7 +11,6 @@ from .decorators import yaml_io
 @yaml_io
 @dataclass(slots=True)
 class ComplexSpectrum:
-
     """Contains a complex spectrum, with spectral weights on a frequency scale.
 
     Attributes:

--- a/python/attoworld/data/frog_data.py
+++ b/python/attoworld/data/frog_data.py
@@ -17,7 +17,6 @@ from .spectrogram import Spectrogram
 @yaml_io
 @dataclass(slots=True)
 class FrogData:
-
     """Stores data from a FROG measurement.
 
     Attributes:

--- a/python/attoworld/data/intensity_spectrum.py
+++ b/python/attoworld/data/intensity_spectrum.py
@@ -19,7 +19,6 @@ from .decorators import yaml_io
 @yaml_io
 @dataclass(slots=True)
 class IntensitySpectrum:
-
     """Contains an intensity spectrum - real valued. SI units.
 
     Attributes:

--- a/python/attoworld/data/luna_result.py
+++ b/python/attoworld/data/luna_result.py
@@ -42,7 +42,6 @@ def inverse_fourier_transform(freq, fullSpectrum):
 
 
 class LunaResult:
-
     """Loads and handles the Luna simulation result.
 
     The result must be in the HDF5 format using the saving option in the Luna.Interface.prop_capillary() function [filepath="..."].

--- a/python/attoworld/data/spectrogram.py
+++ b/python/attoworld/data/spectrogram.py
@@ -19,7 +19,6 @@ from .decorators import yaml_io
 @yaml_io
 @dataclass(slots=True)
 class Spectrogram:
-
     """Contains the data describing a spectrogram.
 
     Attributes:

--- a/python/attoworld/data/spectrometer_calibration.py
+++ b/python/attoworld/data/spectrometer_calibration.py
@@ -11,7 +11,6 @@ from .decorators import yaml_io
 @yaml_io
 @dataclass
 class SpectrometerCalibration:
-
     """Set of data describing a spectrometer calibration.
 
     Attributes:

--- a/python/attoworld/data/spectrometer_calibration_dataset.py
+++ b/python/attoworld/data/spectrometer_calibration_dataset.py
@@ -76,7 +76,6 @@ def calibration_apply_to_spectrogram(self, spectrogram_in):
 @yaml_io
 @dataclass
 class CalibrationInput:
-
     """Input parameters for fitting a calibration curve from a data set."""
 
     wavelength_center: float
@@ -223,7 +222,6 @@ def generate_calibration_from_coeffs(amplitude_coeffs, wavelength_coeffs, wavele
 @yaml_io
 @dataclass
 class CalibrationDataset:
-
     """Collects all of the data related to a spectrometer calibration."""
 
     measurement: IntensitySpectrum

--- a/python/attoworld/data/waveform.py
+++ b/python/attoworld/data/waveform.py
@@ -17,7 +17,6 @@ from .decorators import yaml_io
 @yaml_io
 @dataclass(slots=True)
 class Waveform:
-
     """Contains data describing an electric field waveform.
     In SI units.
 

--- a/python/attoworld/numeric/atomic_units.py
+++ b/python/attoworld/numeric/atomic_units.py
@@ -2,7 +2,6 @@
 
 
 class AtomicUnits:
-
     """Defines various physical constants in atomic units.
 
     Attributes:

--- a/python/attoworld/plot/plot.py
+++ b/python/attoworld/plot/plot.py
@@ -159,7 +159,6 @@ def label_letter(
 
 @dataclass
 class Char:
-
     """Contains useful characters and strings for plot labels.
 
     Examples:

--- a/python/attoworld/spectrum/calibration_data/__init__.py
+++ b/python/attoworld/spectrum/calibration_data/__init__.py
@@ -11,7 +11,6 @@ def get_calibration_path():
 
 
 class CalibrationData(Enum):
-
     """Contains a list of the calibration files store in the module."""
 
     mpq_atto_reso_marco = "MPQ_Atto_Reso_Spectrometer_Marco.npz"
@@ -20,7 +19,6 @@ class CalibrationData(Enum):
 
 
 class CalibrationLampReferences(Enum):
-
     """Contains a list of the calibration lamp references stored in the module."""
 
     mpq_atto_deuterium_halogen = "7315273LS-Deuterium-Halogen_CC-VISNIR.lmp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ use numpy::{IntoPyArray, PyArray1, PyReadonlyArrayDyn};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use std::f64;
-
+use wasm_bindgen::prelude::wasm_bindgen;
+pub use wasm_bindgen_rayon::init_thread_pool;
 /// Functions written in Rust for improved performance and correctness.
 #[pymodule]
 #[pyo3(name = "attoworld_rs")]
@@ -250,6 +251,7 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
     }
 
     /// Sort x,y values in two slices such that x values are in ascending order
+
     fn sort_paired_xy(x_in: &[f64], y_in: &[f64]) -> (Vec<f64>, Vec<f64>) {
         let mut pairs: Vec<(f64, f64)> = x_in
             .iter()
@@ -320,7 +322,8 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
     ///
     /// Returns:
     ///     the interpolated y_out
-    fn interpolate_sorted_1d_slice(
+    #[wasm_bindgen]
+    pub fn interpolate_sorted_1d_slice(
         x_out: &[f64],
         x_in: &[f64],
         y_in: &[f64],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArrayDyn};
 use pyo3::prelude::*;
-use rayon::prelude::*;
 
 use std::f64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use rayon::prelude::*;
 use std::f64;
 use wasm_bindgen::prelude::wasm_bindgen;
 pub use wasm_bindgen_rayon::init_thread_pool;
+
 /// Functions written in Rust for improved performance and correctness.
 #[pymodule]
 #[pyo3(name = "attoworld_rs")]
@@ -29,6 +30,12 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
                 "No maximum value possible; does the array contain a NaN value?",
             )),
         }
+    }
+
+    #[pyfn(m)]
+    /// Call init_thread_pool to allow rayon to work in wasm context
+    fn wasm_init_thread_pool(num_threads: usize) {
+        init_thread_pool(num_threads);
     }
 
     /// Find the first intercept with a value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArrayDyn};
 use pyo3::prelude::*;
 use std::f64;
-
-#[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArrayDyn};
 use pyo3::prelude::*;
-use rayon::prelude::*;
 use std::f64;
+
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
 
 /// Functions written in Rust for improved performance and correctness.
 #[pymodule]
@@ -257,7 +260,14 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
             .zip(y_in.iter())
             .map(|(a, b)| (*a, *b))
             .collect();
-        pairs.par_sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Greater));
+        
+        if cfg!(target_arch = "wasm32") {
+            pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Greater));
+        }
+        else{
+            pairs.par_sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Greater));
+        }
+        
         pairs.into_iter().unzip()
     }
 
@@ -330,38 +340,76 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
         derivative_order: usize,
     ) -> Box<[f64]> {
         let core_stencil_size: usize = 2 * neighbors as usize;
-        x_out
-            .par_iter()
-            .map(|x| {
-                let index: usize = x_in
-                    .binary_search_by(|a| a.partial_cmp(x).unwrap_or(std::cmp::Ordering::Greater))
-                    .unwrap_or_else(|e| e);
-                if (index == 0 || index == x_in.len()) && !extrapolate {
-                    0.0
-                } else {
-                    let clamped_index: usize = index
-                        .clamp(neighbors as usize, (x_in.len() as i64 - neighbors) as usize)
-                        - neighbors as usize;
-                    let stencil_size: usize = if clamped_index == 0
-                        || clamped_index == x_in.len() - (core_stencil_size - 1)
-                    {
-                        core_stencil_size + 1
+        
+        //note that the only difference here is the use of .iter() or .par_iter() at the beginning of the chain.
+        if cfg!(target_arch = "wasm32") {
+            x_out
+                .iter()
+                .map(|x| {
+                    let index: usize = x_in
+                        .binary_search_by(|a| a.partial_cmp(x).unwrap_or(std::cmp::Ordering::Greater))
+                        .unwrap_or_else(|e| e);
+                    if (index == 0 || index == x_in.len()) && !extrapolate {
+                        0.0
                     } else {
-                        core_stencil_size
-                    };
-                    //finite difference stencil with order 0 is interpolation
-                    fornberg_stencil(
-                        derivative_order,
-                        &x_in[clamped_index..(clamped_index + stencil_size)],
-                        *x,
-                    )
-                    .iter()
-                    .zip(y_in.iter().skip(clamped_index))
-                    .map(|(a, b)| a * b)
-                    .sum()
-                }
-            })
-            .collect()
+                        let clamped_index: usize = index
+                            .clamp(neighbors as usize, (x_in.len() as i64 - neighbors) as usize)
+                            - neighbors as usize;
+                        let stencil_size: usize = if clamped_index == 0
+                            || clamped_index == x_in.len() - (core_stencil_size - 1)
+                        {
+                            core_stencil_size + 1
+                        } else {
+                            core_stencil_size
+                        };
+                        //finite difference stencil with order 0 is interpolation
+                        fornberg_stencil(
+                            derivative_order,
+                            &x_in[clamped_index..(clamped_index + stencil_size)],
+                            *x,
+                        )
+                        .iter()
+                        .zip(y_in.iter().skip(clamped_index))
+                        .map(|(a, b)| a * b)
+                        .sum()
+                    }
+                })
+                .collect()
+        } else {
+            x_out
+                .par_iter()
+                .map(|x| {
+                    let index: usize = x_in
+                        .binary_search_by(|a| a.partial_cmp(x).unwrap_or(std::cmp::Ordering::Greater))
+                        .unwrap_or_else(|e| e);
+                    if (index == 0 || index == x_in.len()) && !extrapolate {
+                        0.0
+                    } else {
+                        let clamped_index: usize = index
+                            .clamp(neighbors as usize, (x_in.len() as i64 - neighbors) as usize)
+                            - neighbors as usize;
+                        let stencil_size: usize = if clamped_index == 0
+                            || clamped_index == x_in.len() - (core_stencil_size - 1)
+                        {
+                            core_stencil_size + 1
+                        } else {
+                            core_stencil_size
+                        };
+                        //finite difference stencil with order 0 is interpolation
+                        fornberg_stencil(
+                            derivative_order,
+                            &x_in[clamped_index..(clamped_index + stencil_size)],
+                            *x,
+                        )
+                        .iter()
+                        .zip(y_in.iter().skip(clamped_index))
+                        .map(|(a, b)| a * b)
+                        .sum()
+                    }
+                })
+                .collect()
+        }
+        
     }
 
     /// Use a Fornberg stencil to take a derivative of arbitrary order and accuracy, handling the edge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArrayDyn};
 use pyo3::prelude::*;
-
+use rayon::prelude::*;
 use std::f64;
 
 /// Functions written in Rust for improved performance and correctness.
@@ -257,7 +257,7 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
             .zip(y_in.iter())
             .map(|(a, b)| (*a, *b))
             .collect();
-        pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Greater));
+        pairs.par_sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Greater));
         pairs.into_iter().unzip()
     }
 
@@ -331,7 +331,7 @@ fn attoworld_rs<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()>
     ) -> Box<[f64]> {
         let core_stencil_size: usize = 2 * neighbors as usize;
         x_out
-            .iter()
+            .par_iter()
             .map(|x| {
                 let index: usize = x_in
                     .binary_search_by(|a| a.partial_cmp(x).unwrap_or(std::cmp::Ordering::Greater))


### PR DESCRIPTION
This allows the FROG reconstruction to run entirely in a self-contained marimo wasm notebook.